### PR TITLE
Improve Setanta late-binding logic for globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Upcoming
+
+### Fixed
+
+- Bug where shadowing didn't work as expected.
+
+### Added
+
+- Better catching of undefined variables.
+
 ## 0.10.2 - 2021/11/20
 
 ### Fixed

--- a/demos/nathair.set
+++ b/demos/nathair.set
@@ -33,7 +33,7 @@ creatlach Nathair { >-- An nathair
         xNua := ceann[0] + dx*méid@seo >-- an ait nua X
         yNua := ceann[1] + dy*méid@seo >-- na ait nua Y
 
-        >-- Seiceáil go bhfuil an ait nua idir teorainn an stáitse
+        >-- Seiceáil an bhfuil an ait nua idir teorainn an stáitse
         má xNua < 0 | xNua + méid@seo > X | yNua < 0 | yNua + méid@seo > Y
             toradh breag
 

--- a/rundemos.sh
+++ b/rundemos.sh
@@ -2,6 +2,7 @@
 for i in demos/*.set; do
     f=${i##*/}
     if ! node node_build/cli.js $i < demos/inputs/${f//.set/.in} | diff - demos/outputs/${f//.set/.out}; then
+        echo "$i failed";
         exit 1;
     fi;
 done;

--- a/src/env.ts
+++ b/src/env.ts
@@ -25,9 +25,9 @@ export class Environment {
         return v;
     }
 
-    // Enclosing environment
+    // Enclosing environment.
     public readonly enclosing: Environment | null;
-    // globals contains the collection of global variables
+    // globals contains the collection of global variables.
     private readonly globals: Map<string, Value>;
     // values contains the current values for each variable
     // the mapping of variable name to array index is computed
@@ -39,7 +39,7 @@ export class Environment {
         this.enclosing = enc || null;
         // If we have no enclosing environment, we are
         // the outermost environment, so we construct
-        // the globals
+        // the globals.
         this.globals = enc?.globals ?? new Map();
     }
 

--- a/src/test/builtins.test.ts
+++ b/src/test/builtins.test.ts
@@ -2,7 +2,6 @@ import { isNumber } from "../../src/checks";
 import { Parser, parse } from "../../src/gen_parser";
 import { Interpreter } from "../../src/i10r";
 import { Value } from "../../src/values";
-import { resolveASTNode } from "../../src/bind";
 import { allFadaCombos } from "../../src/builtins";
 
 describe("test fad", () => {
@@ -26,7 +25,7 @@ describe("test fad", () => {
             const p = new Parser(c.inp);
             const res = p.matchExpr(0);
             expect(res).not.toBeNull();
-            const got = await resolveASTNode(res!).evalfn(i.global);
+            const got = await i.evalExpr(res!);
             expect(got).toEqual(c.exp);
         });
     }
@@ -55,7 +54,7 @@ describe("test téacs fns", () => {
             const p = new Parser(c.inp);
             const res = p.matchExpr(0);
             expect(res).not.toBeNull();
-            const got = await resolveASTNode(res!).evalfn(i.global);
+            const got = await i.evalExpr(res!);
             expect(got).toEqual(c.exp);
         });
     }
@@ -83,7 +82,7 @@ describe("test liosta fns", () => {
             const p = new Parser(c.inp);
             const res = p.matchExpr(0);
             expect(res).not.toBeNull();
-            const got = await resolveASTNode(res!).evalfn(i.global);
+            const got = await i.evalExpr(res!);
             expect(got).toEqual(c.exp);
         });
     }
@@ -192,7 +191,7 @@ describe("test go_uimh", () => {
             const p = new Parser(c.inp);
             const res = p.matchExpr(0);
             expect(res).not.toBeNull();
-            const got = await resolveASTNode(res!).evalfn(i.global);
+            const got = await i.evalExpr(res!);
             expect(got).toEqual(c.exp);
         });
     }
@@ -213,7 +212,7 @@ describe("test go_téacs", () => {
             const p = new Parser(c.inp);
             const res = p.matchExpr(0);
             expect(res).not.toBeNull();
-            const got = await resolveASTNode(res!).evalfn(i.global);
+            const got = await i.evalExpr(res!);
             expect(got).toEqual(c.exp);
         });
     }
@@ -239,7 +238,7 @@ describe("uas/íos test", () => {
             const p = new Parser(c.inp);
             const res = p.matchExpr(0);
             expect(res).not.toBeNull();
-            const got = await resolveASTNode(res!).evalfn(i.global);
+            const got = await i.evalExpr(res!);
             expect(got).toEqual(c.exp);
         });
     }
@@ -291,7 +290,7 @@ describe("test mata", () => {
             const p = new Parser(c.inp);
             const res = p.matchExpr(0);
             expect(res).not.toBeNull();
-            const got = await resolveASTNode(res!).evalfn(i.global);
+            const got = await i.evalExpr(res!);
             if (isNumber(got)) {
                 expect(got).toBeCloseTo(c.exp as number);
             } else {


### PR DESCRIPTION
Add smarter lookahead to verify that globals are defined, even if later
in the program. This doesn't eliminate the possibility for runtime
unknown global variable references but should massively reduce their
occurence.

Remove special self definition logic too to enable shadowing.