### PR TITLE
Add builtins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /node_modules/
 *.swp
 /docs/_site/
+run.json
+settings.json


### PR DESCRIPTION
Add more builtins: rith, innéacsuimhir, iarr, and a comhaid object

### `rith( Téacs )`

Runs the command passed in to the program and returns the output

### `innéacsuimhir( Liosta, Value )`

Runs `indexOf` on the Liosta passed in & returns the index of the Value

### `iarr( Téacs, Téacs, Téacs )`

Sends an HTTP request

_I wish I used optional arguments, but couldn't figure out how, if possible at all_

### `oscail@comhaid( Téacs )`

Opens a file and returns the contents

### `sábháil( Téacs, Téacs )`

Writes the content provided to a file

**Sorry for my bad Irish; words used may be odd to an Irish speaker**
